### PR TITLE
Add `Arena::contains_key`

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -175,6 +175,13 @@ impl<K: Key, V> Arena<K, V> {
 			.and_then(|element| element.value.as_mut())
 	}
 
+	/// Returns `true` if the [`Arena`] contains the key.
+	#[inline]
+	#[must_use]
+	pub fn contains_key(&self, key: K) -> bool {
+		self.get(key).is_some()
+	}
+
 	#[inline]
 	fn key_at_next(&self) -> Option<K> {
 		let entry = self.buf.get(self.next);


### PR DESCRIPTION
I did some testing and a simple
```rs
pub fn contains_key(&self, key: K) -> bool {
    self.get(key).is_some()
}
```
compiles to the same code as something that copies `get` like
```rs
pub fn contains_key(&self, key: K) -> bool {
    let entry = self.buf.get(key.index());

    matches!(
        entry.filter(|element| has_version(key, element)),
        Some(Entry {
            value: Value::Occupied { .. },
            ..
        })
    )
}
```