### PR TITLE
Implement `Debug` and `Default` for `Nil`; `Clone` for each iterator

### DIFF
--- a/src/collection.rs
+++ b/src/collection.rs
@@ -5,6 +5,7 @@ use core::ops::{Index, IndexMut};
 
 use crate::{key::Key, version::Version};
 
+#[derive(Clone, Debug)]
 pub(crate) enum Value<T> {
 	Occupied { value: T },
 	Vacant { next: usize },
@@ -33,6 +34,7 @@ impl<T> Value<T> {
 	}
 }
 
+#[derive(Clone, Debug)]
 pub(crate) struct Entry<T, V> {
 	pub value: Value<T>,
 	pub version: V,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -265,6 +265,56 @@ impl<'a, K: Key, V> IntoIterator for &'a mut Arena<K, V> {
 	}
 }
 
+impl<K: Key, V: Clone> Clone for IntoIter<K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			buf: self.buf.clone(),
+			len: self.len,
+		}
+	}
+}
+
+impl<'a, K: Key, V> Clone for Iter<'a, K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			buf: self.buf.clone(),
+			len: self.len,
+		}
+	}
+}
+
+impl<K: Key, V: Clone> Clone for IntoKeys<K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			iter: self.iter.clone(),
+		}
+	}
+}
+
+impl<'a, K: Key, V> Clone for Keys<'a, K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			iter: self.iter.clone(),
+		}
+	}
+}
+
+impl<K: Key, V: Clone> Clone for IntoValues<K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			iter: self.iter.clone(),
+		}
+	}
+}
+
+impl<'a, K: Key, V> Clone for Values<'a, K, V> {
+	fn clone(&self) -> Self {
+		Self {
+			iter: self.iter.clone(),
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use crate::{

--- a/src/version.rs
+++ b/src/version.rs
@@ -28,7 +28,7 @@ pub trait Version: PartialEq + Copy {
 
 /// A no-op versioning strategy. It is useful when you don't care
 /// about the ABA problem.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug, Default)]
 pub struct Nil;
 
 impl Version for Nil {


### PR DESCRIPTION
Also `Clone` and `Debug` for `Value` and `Entry`, but those are private.
(also not actually each iterator, since `Clone` cannot be implemented for the mutable iterators)